### PR TITLE
Add packages.config and include Detours

### DIFF
--- a/version/packages.config
+++ b/version/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Detours" version="4.0.1" targetFramework="native" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
ebb6ab20384af68a203397e4778406e53dde4da1 added a reference to `packages.config` in [version.vcxproj.filters](https://github.com/ServersHub/Framework-ArkServerApi/commit/ebb6ab20384af68a203397e4778406e53dde4da1#diff-0aa9f7e797435e1d17f212f98d081310c4f1cc59e8b292a8725d581f873bec16). However, `packages.config` isn't in the repo. Trying to compile without Detours installed results in an error. Adding this file includes Detours in the project without users having to add it themselves through the Visual Studio menu.