### PR TITLE
Fix: UObject::FindProperty() skips first property

### DIFF
--- a/version/Core/Private/UE/UE.cpp
+++ b/version/Core/Private/UE/UE.cpp
@@ -3,7 +3,7 @@
 
 __declspec(dllexport) UProperty* UObject::FindProperty(FName name)
 {
-    for (UProperty* Property = this->ClassField()->PropertyLinkField(); Property = Property->PropertyLinkNextField();)
+    for (UProperty* Property = ClassField()->PropertyLinkField(); Property != nullptr; Property = Property->PropertyLinkNextField())
         if (Property->NameField().Compare(&name) == 0)
             return Property;
     return nullptr;


### PR DESCRIPTION
`UObject::FindProperty()` currently can not be used to find the first property in a UClass.

Current loop:
```c++
for (UProperty* Property = this->ClassField()->PropertyLinkField(); Property = Property->PropertyLinkNextField();)
```
`UStruct::PropertyLink` points to the first UProperty in the property linked list. `UProperty::PropertyLinkNext` points to the next UProperty in the list. The test condition in the current for-loop advances `Property` to the second UProperty in the list before the loop's first iteration.

Example:
```c++
    FString result;
    UClass* sapTapInv = Globals::FindClass("BlueprintGeneratedClass /Game/PrimalEarth/CoreBlueprints/Inventories/PrimalInventoryBP_TreeSapTap.PrimalInventoryBP_TreeSapTap_C");
    if (!sapTapInv)
        return;

    UProperty* sapTapItem = sapTapInv->ClassDefaultObjectField()->FindProperty(FName("GiveItemClass", EFindName::FNAME_Find));
    if (sapTapItem)
        Log::GetLog()->info("{}", sapTapItem->GetFullName(&result, nullptr)->ToString());
    else
        Log::GetLog()->info("Not found");
```
Output before fix:
```
[info] Not found
```
Output after fix:
```
[info] ClassProperty /Game/PrimalEarth/CoreBlueprints/Inventories/PrimalInventoryBP_TreeSapTap.PrimalInventoryBP_TreeSapTap_C:GiveItemClass
```

Note: `UObject::FindProperty()` is exported by ArkServerApi, so most users won't benefit from this change until a new version is released.