### PR TITLE
Add missing AShooterGameMode::SaveWorld() arg

### DIFF
--- a/version/Core/Private/PluginManager/PluginManager.cpp
+++ b/version/Core/Private/PluginManager/PluginManager.cpp
@@ -344,7 +344,7 @@ namespace API
 				if (save_world)
 				{
 					Log::GetLog()->info("Saving world before reloading plugins ...");
-					ArkApi::GetApiUtils().GetShooterGameMode()->SaveWorld();
+					ArkApi::GetApiUtils().GetShooterGameMode()->SaveWorld(true);
 					Log::GetLog()->info("World saved.");
 
 					save_world = false; // do not save again if multiple plugins are reloaded in this loop

--- a/version/Core/Public/API/ARK/GameMode.h
+++ b/version/Core/Public/API/ARK/GameMode.h
@@ -1119,7 +1119,7 @@ struct AShooterGameMode : AGameMode
 	float GetFloatOptionIni(FString Section, FString OptionName) { return NativeCall<float, FString, FString>(this, "AShooterGameMode.GetFloatOptionIni", Section, OptionName); }
 	int GetIntOptionIni(FString Section, FString OptionName) { return NativeCall<int, FString, FString>(this, "AShooterGameMode.GetIntOptionIni", Section, OptionName); }
 	FString* GetStringOption(FString* result, FString Section, FString OptionName) { return NativeCall<FString*, FString*, FString, FString>(this, "AShooterGameMode.GetStringOption", result, Section, OptionName); }
-	void SaveWorld() { NativeCall<void>(this, "AShooterGameMode.SaveWorld"); }
+	void SaveWorld(bool bForceWaitOnSaveToComplete) { NativeCall<void, bool>(this, "AShooterGameMode.SaveWorld", bForceWaitOnSaveToComplete); }
 	void ClearSavesAndRestart() { NativeCall<void>(this, "AShooterGameMode.ClearSavesAndRestart"); }
 	bool LoadWorld() { return NativeCall<bool>(this, "AShooterGameMode.LoadWorld"); }
 	TSubclassOf<AGameSession>* GetGameSessionClass(TSubclassOf<AGameSession>* result) { return NativeCall<TSubclassOf<AGameSession>*, TSubclassOf<AGameSession>*>(this, "AShooterGameMode.GetGameSessionClass", result); }


### PR DESCRIPTION
This change fixes the definition for `AShooterGameMode::SaveWorld()`, which is missing the `bool bForceWaitOnSaveToComplete` argument that forces the function to wait for the save to complete before returning.

The `AShooterGameMode::SaveWorld()` call in ArkServerApi's `PluginManager::DetectPluginChanges()` is updated to use `bForceWaitOnSaveToComplete = true` to ensure the save has completed before reloading any plugins.